### PR TITLE
fix: disable user to select text on cards

### DIFF
--- a/src/components/CurrentStatus.css
+++ b/src/components/CurrentStatus.css
@@ -7,6 +7,11 @@
   position: relative;
   border-radius: 10px;
   width: 100%;
+
+  -webkit-user-select: none;  
+  -moz-user-select: none;    
+  -ms-user-select: none;      
+  user-select: none;
 }
 
 .cs-bg {

--- a/src/components/carousel/WeatherCard.css
+++ b/src/components/carousel/WeatherCard.css
@@ -9,6 +9,11 @@
   justify-items: center;
   align-items: center;
   background-color: rgba(255, 255, 255, 0.23);
+
+  -webkit-user-select: none;  
+  -moz-user-select: none;    
+  -ms-user-select: none;      
+  user-select: none;
 }
 
 .time span {


### PR DESCRIPTION
So, this PR fixes a minor bug i.e. it disables the user to select the text on cards like the weather detail card or the forecast cards.

-----


https://user-images.githubusercontent.com/56754747/151493701-64782c8c-61a1-4a89-ab3d-7c475f383039.mov

