### PR TITLE
Add GitHub workflows for unit testing, linting and build tests

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -21,7 +21,8 @@
       "no-process-exit": "off",
       "object-shorthand": "off",
       "class-methods-use-this": "off",
-      "react/jsx-filename-extension": [1, { "extensions": [".js", ".jsx"] }]
+      "react/jsx-filename-extension": [1, { "extensions": [".js", ".jsx"] }],
+      "import/no-extraneous-dependencies": ["error", {"devDependencies": ["**/*.test.ts", "src/setupTests.js"]}]
     },
     "plugins": ["prettier","react", "import", "jsx-a11y","react-hooks"],
     "parserOptions": {

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,38 +4,42 @@ on:
   [ push, pull_request ]
 
 jobs:
-  unit_test:
+  unit_tests:
     name: Unit Tests
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: ['12', '14', '16']
+        node: [ '14', '16' ]
+
     steps:
       - uses: actions/checkout@v2
 
-      - name: Setup Node
+      - name: Setup node
         uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node }}
           cache: 'yarn'
 
-      - name: Install Deps
+      - name: Install dependencies
         run: yarn install
 
       - name: Jest Tests
         run: yarn test
 
-  linting:
+  lint:
     name: ESLint
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
 
-      - name: Setup Node
+      - name: Setup node
         uses: actions/setup-node@v2
         with:
           node-version: '16'
           cache: 'yarn'
+
+      - name: Install dependencies
+        run: yarn install
 
       - name: Lint
         run: yarn lint
@@ -46,14 +50,14 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Setup Node
+      - name: Setup node
         uses: actions/setup-node@v2
         with:
           node-version: '16'
           cache: 'yarn'
 
-      - name: Install Deps
+      - name: Install dependencies
         run: yarn install
 
-      - name: build
+      - name: Build
         run: yarn build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,59 @@
+name: Unit Tests
+
+on:
+  [ push, pull_request ]
+
+jobs:
+  unit_test:
+    name: Unit Tests
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node: ['12', '14', '16']
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Setup Node
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ matrix.node }}
+          cache: 'yarn'
+
+      - name: Install Deps
+        run: yarn install
+
+      - name: Jest Tests
+        run: yarn test
+
+  linting:
+    name: ESLint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Setup Node
+        uses: actions/setup-node@v2
+        with:
+          node-version: '16'
+          cache: 'yarn'
+
+      - name: Lint
+        run: yarn lint
+
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Setup Node
+        uses: actions/setup-node@v2
+        with:
+          node-version: '16'
+          cache: 'yarn'
+
+      - name: Install Deps
+        run: yarn install
+
+      - name: build
+        run: yarn build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: Unit Tests
+name: Tests
 
 on:
   [ push, pull_request ]

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "eslint-plugin-prettier": "^4.0.0",
     "eslint-plugin-react": "^7.28.0",
     "eslint-plugin-react-hooks": "^4.3.0",
+    "jest-canvas-mock": "^2.3.1",
     "prettier": "^2.5.1"
   },
   "scripts": {

--- a/src/components/playground/Demo.test.js
+++ b/src/components/playground/Demo.test.js
@@ -1,0 +1,8 @@
+import { render, screen } from '@testing-library/react';
+import Demo from './Demo';
+
+test('renders learn react link', () => {
+  render(<Demo />);
+  const linkElement = screen.getByText(/Sao Paulo/i);
+  expect(linkElement).toBeInTheDocument();
+});

--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -3,3 +3,4 @@
 // expect(element).toHaveTextContent(/react/i)
 // learn more: https://github.com/testing-library/jest-dom
 import '@testing-library/jest-dom';
+import 'jest-canvas-mock';

--- a/yarn.lock
+++ b/yarn.lock
@@ -3763,7 +3763,7 @@ color-name@1.1.3:
   resolved "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz"
   integrity sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=
 
-color-name@^1.0.0, color-name@~1.1.4:
+color-name@^1.0.0, color-name@^1.1.4, color-name@~1.1.4:
   version "1.1.4"
   resolved "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz"
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
@@ -4215,6 +4215,11 @@ cssesc@^3.0.0:
   version "3.0.0"
   resolved "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz"
   integrity sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==
+
+cssfontparser@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/cssfontparser/-/cssfontparser-1.2.1.tgz#f4022fc8f9700c68029d542084afbaf425a3f3e3"
+  integrity sha1-9AIvyPlwDGgCnVQghK+69CWj8+M=
 
 cssnano-preset-default@^4.0.7:
   version "4.0.7"
@@ -6920,6 +6925,14 @@ istanbul-reports@^3.0.2:
     html-escaper "^2.0.0"
     istanbul-lib-report "^3.0.0"
 
+jest-canvas-mock@^2.3.1:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/jest-canvas-mock/-/jest-canvas-mock-2.3.1.tgz#9535d14bc18ccf1493be36ac37dd349928387826"
+  integrity sha512-5FnSZPrX3Q2ZfsbYNE3wqKR3+XorN8qFzDzB5o0golWgt6EOX1+emBnpOc9IAQ+NXFj8Nzm3h7ZdE/9H0ylBcg==
+  dependencies:
+    cssfontparser "^1.2.1"
+    moo-color "^1.0.2"
+
 jest-changed-files@^26.6.2:
   version "26.6.2"
   resolved "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-26.6.2.tgz"
@@ -8057,6 +8070,13 @@ mkdirp@^1.0.3, mkdirp@^1.0.4:
   version "1.0.4"
   resolved "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz"
   integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
+
+moo-color@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/moo-color/-/moo-color-1.0.2.tgz#837c40758d2d58763825d1359a84e330531eca64"
+  integrity sha512-5iXz5n9LWQzx/C2WesGFfpE6RLamzdHwsn3KpfzShwbfIqs7stnoEpaNErf/7+3mbxwZ4s8Foq7I0tPxw7BWHg==
+  dependencies:
+    color-name "^1.1.4"
 
 move-concurrently@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
## Background
Adds GitHub Actions for automated running of Jest tests. Also adds `jest-canvas-mock` as a dev dependency and restores the original test file so Jest works.

Resolves #18  🥳🎉