### PR TITLE
Feat: Guess user location by IP address and use that by default

### DIFF
--- a/src/components/playground/Demo.jsx
+++ b/src/components/playground/Demo.jsx
@@ -22,6 +22,7 @@ import Alerts from '../CriticalAlerts/Alert';
 import ForecastCarousel from '../carousel/ForecastCarousel';
 import Charts from '../Charts/Charts';
 import WeatherSuggestions from '../WeatherSuggestions/Suggestions';
+import IpApi from '../../lib/IpApi/IpApi.mjs';
 
 function Demo() {
   // eslint-disable-next-line no-unused-vars
@@ -36,6 +37,25 @@ function Demo() {
     () => new OpenWeatherMap(process.env.REACT_APP_APIKEY),
     []
   );
+
+  // Initialise by setting location to an approximate obtained through the user's IP address
+  const initState = () => {
+    setIsLoaded(false);
+    new IpApi()
+      .query()
+      .then((res) => {
+        setLocationQuery({ lat: res.latitude, lon: res.longitude });
+      })
+      .catch(() => {
+        setResults(null);
+      })
+      .finally(() => {
+        setIsLoaded(true);
+      });
+  };
+
+  // Initialise app state
+  useEffect(initState, []);
 
   const updateState = () => {
     setIsLoaded(false);

--- a/src/lib/IpApi/IpApi.mjs
+++ b/src/lib/IpApi/IpApi.mjs
@@ -1,0 +1,82 @@
+/**
+ * API wrapper for the 'https://ipapi.co' JSON API
+ * @module
+ */
+
+const apiEndpoint = 'https://ipapi.co/{IP}/json/';
+
+/**
+ * API Wrapper class for https://ipapi.co/json/
+ */
+export default class IpApi {
+  /**
+   * Query the IP Geolocation API
+   * @param {string} ip  IP Address to query. If none is passed, the current IP is queried by default server side.
+   * @returns object  The response, parsed.
+   */
+  async query(ip = '') {
+    const queryUrl = (() => {
+      const sub = ip || '';
+      return apiEndpoint.replace('{IP}', sub);
+    })();
+
+    const response = await (await fetch(queryUrl)).json();
+    const {
+      ip: clientIp,
+      version: ipVersion,
+      city,
+      region,
+      region_code: regionCode,
+      country_code: countryCode,
+      country_code_iso3: countryCodeIso3,
+      country_name: countryName,
+      country_capital: countryCapital,
+      country_tld: countryTld,
+      continent_code: continentCode,
+      in_eu: inEU,
+      postal,
+      latitude,
+      longitude,
+      timezone,
+      utc_offset: utcOffset,
+      country_calling_code: countryCallingCode,
+      currency,
+      currency_name: currencyName,
+      languages,
+      country_area: countryArea,
+      country_population: countryPopulation,
+      asn,
+      org,
+      hostname,
+    } = response;
+
+    return {
+      clientIp,
+      ipVersion,
+      city,
+      region,
+      regionCode,
+      countryCode,
+      countryCodeIso3,
+      countryName,
+      countryCapital,
+      countryTld,
+      continentCode,
+      inEU,
+      postal,
+      latitude,
+      longitude,
+      timezone,
+      utcOffset,
+      countryCallingCode,
+      currency,
+      currencyName,
+      languages,
+      countryArea,
+      countryPopulation,
+      asn,
+      org,
+      hostname,
+    };
+  }
+}


### PR DESCRIPTION
## Context

At the moment we do not have a default location. The first screen of the app has a map statically defaulting to Sao Paulo, BR while all the weather stuff doesn't load until the user searches for a location/uses the location button or selects one on the map. It may be less than apparent that this is a Weather App!

## Summary

Since we decided to not go with asking location permissions on load (instead resigning the functionality to a button), the next best thing we can achieve is guessing the user's approximate location through there IP and using that as the basis for our default screen. This PR uses the handy https://ipapi.co to get information about the user's IP so we can get their approximate coordinates. It works quite well from my tests and makes the overall UX of the app better.

## Testing
There's one caveat: location APIs like the one I use in this PR are blocked out by ad-blockers. This would be easy to circumvent with a server-side proxy but since we're purely static, you'll need to disable your ad-blocker if you use one to see this feature in action. 

**Edit:** This will also need to be tested locally since the deploy has been build without the OpenWeatherMap API key.